### PR TITLE
fix: corrected wrong backend graphql path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To start the backend server, run the following command:
 yarn local
 ```
 
-Congratulations! Your backend is now running at http://localhost:8000/local/graphql.
+Congratulations! Your backend is now running at http://localhost:8000/development/graphql.
 
 ## Communication Channels:
 


### PR DESCRIPTION
## What does this PR do?
Corrected the wrong path mentioned for backend development sever in README.md

Fixes #64 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] This change requires a documentation update

## How should this be tested?
Go to environment setup section of README.md

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
